### PR TITLE
fix: set store false for V2 compaction requests

### DIFF
--- a/src/compact-client-v2.test.ts
+++ b/src/compact-client-v2.test.ts
@@ -109,7 +109,7 @@ describe("executeV2Compaction", () => {
 		}
 	});
 
-	test("appends compaction_trigger to the request input and sets stream: true", async () => {
+	test("appends compaction_trigger and disables response storage", async () => {
 		let requestBody: Record<string, unknown> = {};
 		globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
 			requestBody = JSON.parse(String(init?.body));
@@ -126,6 +126,7 @@ describe("executeV2Compaction", () => {
 		});
 
 		expect(requestBody.stream).toBe(true);
+		expect(requestBody.store).toBe(false);
 		const input = requestBody.input as unknown[];
 		expect(input[input.length - 1]).toEqual({ type: "compaction_trigger" });
 		expect(input.length).toBe(2); // original + compaction_trigger

--- a/src/compact-client-v2.ts
+++ b/src/compact-client-v2.ts
@@ -308,6 +308,7 @@ export async function executeV2Compaction(
 	const requestBody = {
 		...request,
 		input: [...request.input, { type: "compaction_trigger" }],
+		store: false,
 		stream: true,
 	};
 


### PR DESCRIPTION
## Summary

- send `store: false` on V2 Responses compaction requests
- add a regression assertion for the serialized request body

## Why

ChatGPT Codex Responses requires response storage to be disabled. With pi 0.84.3, `openai-codex-responses`, and `gpt-5.6-sol`, the current V2 request reaches:

```text
POST https://chatgpt.com/backend-api/codex/responses
HTTP 400
{"detail":"Store must be set to false"}
```

The normal pi Codex request already sets `store: false`, but the extension's independently-built V2 request currently omits it. This makes native compaction fail open to Pi's textual summary path.

Placing `store: false` after `...request` also prevents a captured or future request field from overriding the required value.

## Verification

```text
bun test
121 pass
0 fail
326 expect() calls
```
