### PR TITLE
fix: resolve native runtime from session model

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -201,12 +201,16 @@ export async function resolveNativeCompactionEnvironment(
 		};
 	}
 
-	const modelChange = ctx.sessionManager.getBranch().findLast((entry) => entry.type === "model_change");
-	const currentModel =
-		ctx.model ??
-		(modelChange?.type === "model_change"
-			? ctx.modelRegistry.find(modelChange.provider, modelChange.modelId)
-			: undefined);
+	let sessionModel: RuntimeModel | undefined;
+	const branch = ctx.sessionManager.getBranch();
+	for (let index = branch.length - 1; index >= 0; index -= 1) {
+		const entry = branch[index];
+		if (entry?.type === "model_change") {
+			sessionModel = ctx.modelRegistry.find(entry.provider, entry.modelId);
+			break;
+		}
+	}
+	const currentModel = ctx.model ?? sessionModel;
 	const descriptor = getRuntimeModelDescriptor(currentModel);
 	if (!currentModel || !descriptor.provider || !descriptor.api || !descriptor.model) {
 		return {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -201,7 +201,12 @@ export async function resolveNativeCompactionEnvironment(
 		};
 	}
 
-	const currentModel = ctx.model;
+	const modelChange = ctx.sessionManager.getBranch().findLast((entry) => entry.type === "model_change");
+	const currentModel =
+		ctx.model ??
+		(modelChange?.type === "model_change"
+			? ctx.modelRegistry.find(modelChange.provider, modelChange.modelId)
+			: undefined);
 	const descriptor = getRuntimeModelDescriptor(currentModel);
 	if (!currentModel || !descriptor.provider || !descriptor.api || !descriptor.model) {
 		return {


### PR DESCRIPTION
Pi can invoke `session_before_compact` with `ctx.model` unset even when the latest session `model_change` identifies the active model. Resolve that entry only as a fallback.

— PI[gpt-5.6-terra]